### PR TITLE
担当授業のカードのコンポーネントを実装した

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1021,37 +1021,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
     },
-    "node_modules/@radix-ui/react-accordion": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
-      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collapsible": "1.1.12",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -1082,36 +1051,6 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
-      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "professor-s-compendium-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-aspect-ratio": "^1.1.7",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-separator": "^1.1.7",
@@ -1020,6 +1021,37 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
     },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -1050,6 +1082,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-separator": "^1.1.7",

--- a/src/app/professor/[name]/_component/LessonCard.tsx
+++ b/src/app/professor/[name]/_component/LessonCard.tsx
@@ -14,7 +14,7 @@ type LessonCardProps = {
 
 const LessonCard: React.FC<LessonCardProps> = ({ lesson }) => {
   return (
-    <div className="border border-gray-300 rounded-[24px] p-7 lg:mx-50 ">
+    <div className="border border-gray-300 rounded-[24px] p-7 lg:mx-50 mx-5 ">
       <p className="text-lg font-bold mb-2">{lesson.courseName}</p>
       <p className="text-gray-500">{lesson.description}</p>
       <Accordion type="single" collapsible className="w-full py-2">

--- a/src/app/professor/[name]/_component/LessonCard.tsx
+++ b/src/app/professor/[name]/_component/LessonCard.tsx
@@ -33,9 +33,13 @@ const LessonCard: React.FC<LessonCardProps> = ({ lesson }) => {
         <AccordionItem value="item-3">
           <AccordionTrigger className="text-md">関連する資格</AccordionTrigger>
           <AccordionContent className="flex flex-col gap-4">
-            <p className="text-gray-500 text-md">
-              {lesson.relatedQualification}
-            </p>
+            {lesson.relatedQualification ? (
+              <p className="text-gray-500 text-md">
+                {lesson.relatedQualification}
+              </p>
+            ) : (
+              <p className="text-gray-500 text-md">関連する資格はありません</p>
+            )}
           </AccordionContent>
         </AccordionItem>
       </Accordion>

--- a/src/app/professor/[name]/_component/LessonCard.tsx
+++ b/src/app/professor/[name]/_component/LessonCard.tsx
@@ -5,48 +5,59 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
+import { Lesson } from "./LessonListView";
+import { ExternalLink } from "lucide-react";
 
-const LessonCard = () => {
+type LessonCardProps = {
+  lesson: Lesson;
+};
+
+const LessonCard: React.FC<LessonCardProps> = ({ lesson }) => {
   return (
     <div className="border border-gray-300 rounded-[24px] p-7 lg:mx-50 ">
-      <p className="text-lg font-bold mb-2">憲法 I</p>
-      <p className="text-gray-500">
-        日本国憲法の基本原理と運用について学びます。到達目標は基本的人権論の意義と内容を知り、基礎知識を正確に踏まえて論述できるようになることです。
-      </p>
+      <p className="text-lg font-bold mb-2">{lesson.courseName}</p>
+      <p className="text-gray-500">{lesson.description}</p>
       <Accordion type="single" collapsible className="w-full py-2">
         <AccordionItem value="item-1">
           <AccordionTrigger className="text-md">学べること</AccordionTrigger>
           <AccordionContent className="flex flex-col gap-4">
-            <p className="text-gray-500 text-md">
-              日本国憲法の基本原理と運用について学びます。到達目標は基本的人権論の意義と内容を知り、基礎知識を正確に踏まえて論述できるようになることです。
-            </p>
+            <p className="text-gray-500 text-md">{lesson.learningPoints}</p>
           </AccordionContent>
         </AccordionItem>
         <AccordionItem value="item-2">
           <AccordionTrigger className="text-md">授業形式</AccordionTrigger>
           <AccordionContent className="flex flex-col gap-4">
-            <p className="text-gray-500 text-md">
-              日本国憲法の基本原理と運用について学びます。到達目標は基本的人権論の意義と内容を知り、基礎知識を正確に踏まえて論述できるようになることです。
-            </p>
+            <p className="text-gray-500 text-md">{lesson.style}</p>
           </AccordionContent>
         </AccordionItem>
         <AccordionItem value="item-3">
           <AccordionTrigger className="text-md">関連する資格</AccordionTrigger>
           <AccordionContent className="flex flex-col gap-4">
             <p className="text-gray-500 text-md">
-              日本国憲法の基本原理と運用について学びます。到達目標は基本的人権論の意義と内容を知り、基礎知識を正確に踏まえて論述できるようになることです。
+              {lesson.relatedQualification}
             </p>
           </AccordionContent>
         </AccordionItem>
       </Accordion>
       <div className="flex gap-2">
         <p>対象学年:</p>
-        <Badge className="bg-[#fff7f9] text-[#FF8888] border border-[#FF8888] rounded-full px-4">
-          1年生
-        </Badge>
-        <Badge className="bg-[#fff7f9] text-[#FF8888] border border-[#FF8888] rounded-full px-4">
-          2年生
-        </Badge>
+        {lesson.targetGrade.map((grade) => (
+          <Badge
+            key={grade}
+            className="bg-[#fff7f9] text-[#FF8888] border border-[#FF8888] rounded-full px-4"
+          >
+            {grade}
+          </Badge>
+        ))}
+      </div>
+      <div className="mt-4">
+        <a
+          href={lesson.syllabusLinkUrl}
+          className="text-gray-500 flex items-center gap-2"
+        >
+          シラバスを見る
+          <ExternalLink className="w-4 h-4" />
+        </a>
       </div>
     </div>
   );

--- a/src/app/professor/[name]/_component/LessonCard.tsx
+++ b/src/app/professor/[name]/_component/LessonCard.tsx
@@ -1,0 +1,55 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+
+const LessonCard = () => {
+  return (
+    <div className="border border-gray-300 rounded-[24px] p-7 lg:mx-50 ">
+      <p className="text-lg font-bold mb-2">憲法 I</p>
+      <p className="text-gray-500">
+        日本国憲法の基本原理と運用について学びます。到達目標は基本的人権論の意義と内容を知り、基礎知識を正確に踏まえて論述できるようになることです。
+      </p>
+      <Accordion type="single" collapsible className="w-full py-2">
+        <AccordionItem value="item-1">
+          <AccordionTrigger className="text-md">学べること</AccordionTrigger>
+          <AccordionContent className="flex flex-col gap-4">
+            <p className="text-gray-500 text-md">
+              日本国憲法の基本原理と運用について学びます。到達目標は基本的人権論の意義と内容を知り、基礎知識を正確に踏まえて論述できるようになることです。
+            </p>
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-2">
+          <AccordionTrigger className="text-md">授業形式</AccordionTrigger>
+          <AccordionContent className="flex flex-col gap-4">
+            <p className="text-gray-500 text-md">
+              日本国憲法の基本原理と運用について学びます。到達目標は基本的人権論の意義と内容を知り、基礎知識を正確に踏まえて論述できるようになることです。
+            </p>
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-3">
+          <AccordionTrigger className="text-md">関連する資格</AccordionTrigger>
+          <AccordionContent className="flex flex-col gap-4">
+            <p className="text-gray-500 text-md">
+              日本国憲法の基本原理と運用について学びます。到達目標は基本的人権論の意義と内容を知り、基礎知識を正確に踏まえて論述できるようになることです。
+            </p>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+      <div className="flex gap-2">
+        <p>対象学年:</p>
+        <Badge className="bg-[#fff7f9] text-[#FF8888] border border-[#FF8888] rounded-full px-4">
+          1年生
+        </Badge>
+        <Badge className="bg-[#fff7f9] text-[#FF8888] border border-[#FF8888] rounded-full px-4">
+          2年生
+        </Badge>
+      </div>
+    </div>
+  );
+};
+
+export default LessonCard;

--- a/src/app/professor/[name]/_component/LessonListView.tsx
+++ b/src/app/professor/[name]/_component/LessonListView.tsx
@@ -2,14 +2,31 @@ import HeadLine from "@/components/HeadLine";
 import { BookOpen } from "lucide-react";
 import LessonCard from "./LessonCard";
 
-const LessonListView = () => {
+export type Lesson = {
+  PK: string;
+  SK: string;
+  courseName: string;
+  description: string;
+  learningPoints: string;
+  style: string;
+  relatedQualification: string | null;
+  targetGrade: string[];
+  courseCode: string;
+  syllabusLinkUrl: string;
+};
+
+type LessonListViewProps = {
+  lessons: Lesson[];
+};
+
+const LessonListView: React.FC<LessonListViewProps> = ({ lessons }) => {
   return (
     <div className="mt-10">
       <HeadLine icon={<BookOpen className="w-10 h-10 " />} title="担当授業" />
       <div className="mt-5 space-y-4">
-        <LessonCard />
-        <LessonCard />
-        <LessonCard />
+        {lessons.map((lesson) => (
+          <LessonCard key={lesson.SK} lesson={lesson} />
+        ))}
       </div>
     </div>
   );

--- a/src/app/professor/[name]/_component/LessonListView.tsx
+++ b/src/app/professor/[name]/_component/LessonListView.tsx
@@ -1,0 +1,18 @@
+import HeadLine from "@/components/HeadLine";
+import { BookOpen } from "lucide-react";
+import LessonCard from "./LessonCard";
+
+const LessonListView = () => {
+  return (
+    <div className="mt-10">
+      <HeadLine icon={<BookOpen className="w-10 h-10 " />} title="担当授業" />
+      <div className="mt-5 space-y-4">
+        <LessonCard />
+        <LessonCard />
+        <LessonCard />
+      </div>
+    </div>
+  );
+};
+
+export default LessonListView;

--- a/src/app/professor/[name]/page.client.tsx
+++ b/src/app/professor/[name]/page.client.tsx
@@ -2,8 +2,11 @@
 import ProfessorProfileCard from "./_component/ProfessorProfileCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ProfileView from "./_component/ProfileView";
-import ProfessorPersonalView, { ProfessorPersonalData } from "./_component/ProfessorPersonalView";
+import ProfessorPersonalView, {
+  ProfessorPersonalData,
+} from "./_component/ProfessorPersonalView";
 import SeminarInfoView from "./_component/SeminarInfoView";
+import LessonListView from "./_component/LessonListView";
 
 type ClientProfessorPageProps = {
   xLink: string;
@@ -44,7 +47,6 @@ const ClientProfessorPage: React.FC<ClientProfessorPageProps> = ({
   seminarDescriptionImage,
   careerHistory,
 }) => {
-  
   return (
     <>
       <ProfessorProfileCard
@@ -85,7 +87,7 @@ const ClientProfessorPage: React.FC<ClientProfessorPageProps> = ({
             />
           </TabsContent>
           <TabsContent value="course" className="w-full">
-            ここは担当授業画面です
+            <LessonListView />
           </TabsContent>
           <TabsContent value="seminor-info" className="w-full">
             <SeminarInfoView

--- a/src/app/professor/[name]/page.client.tsx
+++ b/src/app/professor/[name]/page.client.tsx
@@ -6,7 +6,7 @@ import ProfessorPersonalView, {
   ProfessorPersonalData,
 } from "./_component/ProfessorPersonalView";
 import SeminarInfoView from "./_component/SeminarInfoView";
-import LessonListView from "./_component/LessonListView";
+import LessonListView, { Lesson } from "./_component/LessonListView";
 
 type ClientProfessorPageProps = {
   xLink: string;
@@ -28,6 +28,7 @@ type ClientProfessorPageProps = {
     event: string;
     photo: string | null;
   }[];
+  lessons: Lesson[];
 };
 
 const ClientProfessorPage: React.FC<ClientProfessorPageProps> = ({
@@ -46,6 +47,7 @@ const ClientProfessorPage: React.FC<ClientProfessorPageProps> = ({
   seminarDescription,
   seminarDescriptionImage,
   careerHistory,
+  lessons,
 }) => {
   return (
     <>
@@ -87,14 +89,14 @@ const ClientProfessorPage: React.FC<ClientProfessorPageProps> = ({
             />
           </TabsContent>
           <TabsContent value="course" className="w-full">
-            <LessonListView />
+            <LessonListView lessons={lessons} />
           </TabsContent>
           <TabsContent value="seminor-info" className="w-full">
             <SeminarInfoView
-               seminarName={seminarName}
-               seminarDescription={seminarDescription}
-               seminarDescriptionImage={seminarDescriptionImage}
-             />
+              seminarName={seminarName}
+              seminarDescription={seminarDescription}
+              seminarDescriptionImage={seminarDescriptionImage}
+            />
           </TabsContent>
           <TabsContent value="personal" className="w-full">
             <ProfessorPersonalView personalData={personalData} />

--- a/src/app/professor/[name]/page.tsx
+++ b/src/app/professor/[name]/page.tsx
@@ -37,7 +37,7 @@ export default async function ProfessorPage({
     (item) => item.PK === `PROF#${professorId}` && item.SK === "PERSONAL"
   );
   // 授業情報を取得
-  const rawLessons = mockData.filter(
+  const lessons = mockData.filter(
     (item) => item.PK === `PROF#${professorId}` && item.SK.startsWith("COURSE#")
   );
 
@@ -67,7 +67,7 @@ export default async function ProfessorPage({
         seminarDescription={seminar?.description || ""}
         seminarDescriptionImage={seminar?.descriptionImage || ""}
         careerHistory={profile?.careerHistory || []}
-        lessons={rawLessons as Lesson[]}
+        lessons={lessons as Lesson[]}
       />
     </>
   );

--- a/src/app/professor/[name]/page.tsx
+++ b/src/app/professor/[name]/page.tsx
@@ -1,6 +1,7 @@
 import mockData from "@/data/mock-db.json";
 import ClientProfessorPage from "./page.client";
 import { ProfessorPersonalData } from "./_component/ProfessorPersonalView";
+import { Lesson } from "./_component/LessonListView";
 
 export default async function ProfessorPage({
   params,
@@ -35,6 +36,10 @@ export default async function ProfessorPage({
   const personal = mockData.find(
     (item) => item.PK === `PROF#${professorId}` && item.SK === "PERSONAL"
   );
+  // 授業情報を取得
+  const rawLessons = mockData.filter(
+    (item) => item.PK === `PROF#${professorId}` && item.SK.startsWith("COURSE#")
+  );
 
   if (!basicInfo) {
     return (
@@ -62,6 +67,7 @@ export default async function ProfessorPage({
         seminarDescription={seminar?.description || ""}
         seminarDescriptionImage={seminar?.descriptionImage || ""}
         careerHistory={profile?.careerHistory || []}
+        lessons={rawLessons as Lesson[]}
       />
     </>
   );

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDownIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  );
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -35,13 +35,13 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
           className
         )}
         {...props}
       >
         {children}
-        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+        <ChevronDownIcon className="text-gray-400 pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
   );
@@ -55,7 +55,7 @@ function AccordionContent({
   return (
     <AccordionPrimitive.Content
       data-slot="accordion-content"
-      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-md"
       {...props}
     >
       <div className={cn("pt-0 pb-4", className)}>{children}</div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/data/mock-db.json
+++ b/src/data/mock-db.json
@@ -186,7 +186,7 @@
     "relatedQualification": "公認会計士（一部）",
     "targetGrade": ["1年生", "2年生"],
     "courseCode": "EC101",
-    "syllabusLinkUrl": "https://hogehoge"
+    "syllabusLinkUrl": "https://portal.seikei.ac.jp/campusweb/slbssrch.do"
   },
   {
     "PK": "PROF#TANAKA",
@@ -194,11 +194,11 @@
     "courseName": "ゲーム理論",
     "description": "戦略的意思決定を数理的に分析します。",
     "learningPoints": "交渉力・分析力を養う",
-    "learningStyle": "演習・講義",
+    "style": "演習・講義",
     "relatedQualification": null,
-    "targetGrade": ["3年生以上"],
+    "targetGrade": ["3年生", "4年生"],
     "courseCode": "EC305",
-    "syllabusLinkUrl": "https://hogehoge"
+    "syllabusLinkUrl": "https://portal.seikei.ac.jp/campusweb/slbssrch.do"
   },
 
   {


### PR DESCRIPTION
## やったこと

 - LessonCardを実装した

## 変更内容

- [x] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

## 関連 Issue

- Closes #53 

## スクリーンショット
### PC
<img width="1470" height="796" alt="スクリーンショット 2025-09-07 19 25 47" src="https://github.com/user-attachments/assets/585788ec-ceac-4e58-a366-8550bf93414c" />

### MP
<img width="331" height="709" alt="スクリーンショット 2025-09-07 19 26 10" src="https://github.com/user-attachments/assets/c18824e5-acb8-4ccd-a880-a9a1384fd756" />


## レビュアーへのメモ

- モックデータで授業形式がlearningStyleとstyleがあったので、figma通りstyleに統一した

## その他

- 別ブランチでやること
   - 授業が４つ以上の場合、３つで表示させてボタンを押すと全て見れるようになる仕様を実装する
