### PR TITLE
活動曜日を作成

### DIFF
--- a/src/app/professor/[name]/_component/SeminarInfoView.tsx
+++ b/src/app/professor/[name]/_component/SeminarInfoView.tsx
@@ -6,9 +6,15 @@ interface SeminarInfoViewProps {
   seminarName: string;
   seminarDescription: string;
   seminarDescriptionImage: string;
+  activityDay: string[];
 }
-const SeminarInfoView= ({ seminarName, seminarDescription, seminarDescriptionImage }: SeminarInfoViewProps) => {
-    return (
+const SeminarInfoView = ({
+  seminarName,
+  seminarDescription,
+  seminarDescriptionImage,
+  activityDay,
+}: SeminarInfoViewProps) => {
+  return (
     <div className="mt-10">
       <HeadLine
         icon={<FlaskConical className="w-10 h-10 "/>}
@@ -34,8 +40,29 @@ const SeminarInfoView= ({ seminarName, seminarDescription, seminarDescriptionIma
           </p>
         </div>
       </div>
+      <div className="lg:ml-50 mt-10 px-6 lg:px-0">
+        <h2 className="text-xl font-bold mb-2">活動曜日・頻度</h2>
+        {activityDay && activityDay.length > 0 ? (
+          activityDay.map((day, index) => {
+            // 曜日とそれ以外の情報（今は時限）を分ける
+            const parts = day.split(" ");
+            const dayOfWeek = parts[0] || "";
+            const period = parts[1] || "";
+
+            return (
+              <div key={index} className="flex items-center mb-1 text-lg">
+                <span className="mr-2">・</span>
+                <span className="font-bold">{dayOfWeek}</span>
+                <span className="ml-4">{period}</span>
+              </div>
+            );
+          })
+        ) : (
+          <p>活動日の情報がありません</p>
+        )}
+      </div>
     </div>
   );
-    }
+};
 
 export default SeminarInfoView;

--- a/src/app/professor/[name]/page.client.tsx
+++ b/src/app/professor/[name]/page.client.tsx
@@ -23,6 +23,7 @@ type ClientProfessorPageProps = {
   personalData: ProfessorPersonalData;
   seminarDescription: string;
   seminarDescriptionImage: string;
+  activityDay: string[];
   careerHistory: {
     year: string;
     event: string;
@@ -46,6 +47,7 @@ const ClientProfessorPage: React.FC<ClientProfessorPageProps> = ({
   personalData,
   seminarDescription,
   seminarDescriptionImage,
+  activityDay,
   careerHistory,
   lessons,
 }) => {
@@ -96,6 +98,7 @@ const ClientProfessorPage: React.FC<ClientProfessorPageProps> = ({
               seminarName={seminarName}
               seminarDescription={seminarDescription}
               seminarDescriptionImage={seminarDescriptionImage}
+              activityDay={activityDay}
             />
           </TabsContent>
           <TabsContent value="personal" className="w-full">

--- a/src/app/professor/[name]/page.tsx
+++ b/src/app/professor/[name]/page.tsx
@@ -66,6 +66,7 @@ export default async function ProfessorPage({
         personalData={(personal || {}) as ProfessorPersonalData}
         seminarDescription={seminar?.description || ""}
         seminarDescriptionImage={seminar?.descriptionImage || ""}
+        activityDay={seminar?.activityDay || []}
         careerHistory={profile?.careerHistory || []}
         lessons={lessons as Lesson[]}
       />


### PR DESCRIPTION
## やったこと
教授ページのゼミ概要の下に活動曜日・頻度を追加
<!-- このPRで何を行ったかを簡潔に説明してください -->

## 変更内容
- `SeminarInfoView.tsx`を編集して、ゼミ概要の下に「活動曜日・頻度」を追加
  - 文字列が曜日とそれ以外で分けるよう記述（例:「水曜日 5限」の場合、[水曜日,5限]となる）
- モックデータ activityDayを参照できるように`page.client.tsx`,`page.tsx`に記述を追加
<!-- 変更した内容を詳しく記載してください -->

- [x] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

- Closes #57 

## スクリーンショット
<img width="281" height="337" alt="image" src="https://github.com/user-attachments/assets/f86a480c-1d5c-4f14-8b66-c68f6b1700e4" />

## レビュアーへのメモ

<!-- レビュアーに特に注意して見てほしいポイントなどがあれば記載してください -->

## その他

<!-- 補足情報や注意点があれば記載してください -->
