### PR TITLE
ゼミの特徴・キーワードのUIを追加

### DIFF
--- a/src/app/professor/[name]/_component/SeminarInfoView.tsx
+++ b/src/app/professor/[name]/_component/SeminarInfoView.tsx
@@ -2,6 +2,7 @@ import HeadLine from "@/components/HeadLine";
 import { FlaskConical } from "lucide-react";
 import Image from "next/image";
 import { SeminarSchedule } from "../_component/SeminarSchedule";
+import { Badge } from "@/components/ui/badge";
 
 interface SeminarInfoViewProps {
   seminarName: string;
@@ -12,6 +13,7 @@ interface SeminarInfoViewProps {
     task: string;
   }[];
   activityDay: string[];
+  keywords: string[];
 }
 
 const SeminarInfoView = ({
@@ -20,6 +22,7 @@ const SeminarInfoView = ({
   seminarDescriptionImage,
   seminarSchedule,
   activityDay,
+  keywords,
 }: SeminarInfoViewProps) => {
   return (
     <div className="mt-10">
@@ -76,26 +79,42 @@ const SeminarInfoView = ({
           </p>
         </div>
       </div>
-      <div className="lg:ml-50 mt-10 px-6 lg:px-0">
-        <h2 className="text-xl font-bold mb-2">活動曜日・頻度</h2>
-        {activityDay && activityDay.length > 0 ? (
-          activityDay.map((day, index) => {
-            // 曜日とそれ以外の情報（今は時限）を分ける
-            const parts = day.split(" ");
-            const dayOfWeek = parts[0] || "";
-            const period = parts[1] || "";
+      <div className="flex justify-center items-start mt-10 gap-50">
+        <div>
+          <h2 className="text-xl font-bold mb-2">活動曜日・頻度</h2>
+          {activityDay && activityDay.length > 0 ? (
+            activityDay.map((day, index) => {
+              // 曜日とそれ以外の情報（今は時限）を分ける
+              const parts = day.split(" ");
+              const dayOfWeek = parts[0] || "";
+              const period = parts[1] || "";
 
-            return (
-              <div key={index} className="flex items-center mb-1 text-lg">
-                <span className="mr-2">・</span>
-                <span className="font-bold">{dayOfWeek}</span>
-                <span className="ml-4">{period}</span>
-              </div>
-            );
-          })
-        ) : (
-          <p>活動日の情報がありません</p>
-        )}
+              return (
+                <div key={index} className="flex items-center mb-1 text-lg">
+                  <span className="mr-2">・</span>
+                  <span className="font-bold">{dayOfWeek}</span>
+                  <span className="ml-4">{period}</span>
+                </div>
+              );
+            })
+          ) : (
+            <p>活動日の情報がありません</p>
+          )}
+        </div>
+        <div>
+          <h2 className="text-xl font-bold mb-2">特徴・キーワード</h2>
+          {keywords.map((keyword) => (
+            <Badge
+              key={keyword}
+              className="flex flex-col bg-[#fff7f9] text-[#FF8888] border border-[#FF8888] rounded-full px-4 m-2 text-sm"
+            >
+              # {keyword}
+            </Badge>
+          ))}
+        </div>
+        <div>
+          <h2 className="text-xl font-bold mb-2">卒業生の研究テーマ</h2>
+        </div>
       </div>
     </div>
   );

--- a/src/app/professor/[name]/page.client.tsx
+++ b/src/app/professor/[name]/page.client.tsx
@@ -24,6 +24,7 @@ type ClientProfessorPageProps = {
   seminarDescription: string;
   seminarDescriptionImage: string;
   activityDay: string[];
+  keywords: string[];
   careerHistory: {
     year: string;
     event: string;
@@ -52,6 +53,7 @@ const ClientProfessorPage: React.FC<ClientProfessorPageProps> = ({
   seminarDescription,
   seminarDescriptionImage,
   activityDay,
+  keywords,
   careerHistory,
   seminarSchedule,
   lessons,
@@ -105,6 +107,7 @@ const ClientProfessorPage: React.FC<ClientProfessorPageProps> = ({
                seminarDescriptionImage={seminarDescriptionImage}
                seminarSchedule={seminarSchedule}
                activityDay={activityDay}
+               keywords={keywords}
              />
           </TabsContent>
           <TabsContent value="personal" className="w-full">

--- a/src/app/professor/[name]/page.tsx
+++ b/src/app/professor/[name]/page.tsx
@@ -67,6 +67,7 @@ export default async function ProfessorPage({
         seminarDescription={seminar?.description || ""}
         seminarDescriptionImage={seminar?.descriptionImage || ""}
         activityDay={seminar?.activityDay || []}
+        keywords={seminar?.keywords || []}
         careerHistory={profile?.careerHistory || []}
         seminarSchedule={seminar?.annualSchedule || []}
         lessons={lessons as Lesson[]}


### PR DESCRIPTION
## やったこと
教授ページのゼミ情報の「活動曜日・頻度」の隣に **「特徴・キーワード」を追加**

<!-- このPRで何を行ったかを簡潔に説明してください -->

## 変更内容
- `SeminarInfoView.tsx`を編集して、「活動曜日・頻度」の隣に「特徴・キーワード」を追加
  - 「活動曜日・頻度」・「特徴・キーワード」・「卒業生の研究テーマ」が横並びになるよう、これらを親divタグで囲む
    - 3要素の場所がわかりやすいよう「卒業生の研究テーマ」タイトルだけ追加
    - 変更に伴って「活動曜日・頻度」のCSSを一部変更
- モックデータ keywordを参照できるように`page.client.tsx`,`page.tsx`に記述を追加
<!-- 変更した内容を詳しく記載してください -->

- [x] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

- Closes #65 

## スクリーンショット
<img width="934" height="134" alt="image" src="https://github.com/user-attachments/assets/5bba8611-0f14-41bf-afbb-2049fd067ca9" />

位置関係がわかりやすいように、隣り合う「活動曜日・頻度」と「卒業生の研究テーマ」も併せて載せています。

## レビュアーへのメモ
<!-- レビュアーに特に注意して見てほしいポイントなどがあれば記載してください -->

## その他
<img width="427" height="495" alt="image" src="https://github.com/user-attachments/assets/d03fb169-0096-4833-9c8e-dbc4f9dd224b" />

figmaでは、「研究の進め方」→「年間スケジュール」→「活動頻度」の順だけど、
今のコードは「年間スケジュール」→「研究の進め方」→「活動頻度」で、
順番が同じになっていないところは変更の意図で捉えて大丈夫か気になります。
<!-- 補足情報や注意点があれば記載してください -->
