### PR TITLE
ゼミ情報のUIをfigma通りにする

### DIFF
--- a/src/app/professor/[name]/_component/SeminarInfoView.tsx
+++ b/src/app/professor/[name]/_component/SeminarInfoView.tsx
@@ -50,26 +50,18 @@ const SeminarInfoView = ({
           </p>
         </div>
       </div>
-      <div className="mt-10">
-        <div className="flex mx-4 lg:mx-50 gap-2 items-center">
-          <p className="text-lg lg:text-2xl font-bold">年間スケジュール</p>
-        </div>
-        <div className="mt-30">
-          <SeminarSchedule seminarSchedule={seminarSchedule} />
-        </div>
-      </div>
       <div className="flex mx-4 lg:mx-50 gap-2 items-center mt-10">
-        <h1 className="text-lg lg:text-2xl font-bold">研究の流れ</h1>
+        <h1 className="text-lg lg:text-2xl font-bold">研究の進め方</h1>
       </div>
       <div className="flex flex-col lg:flex-row gap-5 lg:gap-10 mt-5">
         <div className="flex-shrink-0 order-2 lg:order-2">
           <div className="lg:pr-50">
             <Image
-                src="/ProfileExample.png"
-                alt="researchProcessImage"
-                width={500}
-                height={400}
-                className="object-cover w-full max-w-[300px] lg:max-w-[500px] h-[240px] mx-auto"
+              src="/ProfileExample.png"
+              alt="researchProcessImage"
+              width={500}
+              height={400}
+              className="object-cover w-full max-w-[300px] lg:max-w-[500px] h-[240px] mx-auto"
             />
           </div>
         </div>
@@ -77,6 +69,14 @@ const SeminarInfoView = ({
           <p>
             このゼミでは、平安時代の文学であればどの作品を研究しても構いません。「落窪物語」「伊勢物語」「竹取物語」「枕草子」「とりかへばや物語」など、多様な作品が研究対象となっています。国宝の「源氏物語絵巻」や漫画「あさきゆめみし」など、「源氏物語」の絵画化作品を取り上げる人もいます。とはいえ、人気があるのはやはり「源氏物語」。或る登場人物--例えば紫の上に焦点を当てたり、或る場面--例えば光源氏と紫の上が出会う場面を丁寧に読み解いたり、或る物--例えば牛車に注目して作品を分析したり、といったように研究テーマは多様です。
           </p>
+        </div>
+      </div>
+      <div className="mt-10">
+        <div className="flex mx-4 lg:mx-50 gap-2 items-center">
+          <p className="text-lg lg:text-2xl font-bold">年間スケジュール</p>
+        </div>
+        <div className="mt-30">
+          <SeminarSchedule seminarSchedule={seminarSchedule} />
         </div>
       </div>
       <div className="flex justify-center items-start mt-10 gap-50">


### PR DESCRIPTION
## やったこと
ゼミ情報のUIを「研究の進め方」→「年間スケジュール」→「活動頻度」の順に並び替える
<!-- このPRで何を行ったかを簡潔に説明してください -->

## 変更内容

<!-- 変更した内容を詳しく記載してください -->

- [ ] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] その他: コードの順番を変える

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

- Closes #76 

## スクリーンショット
<img width="950" height="905" alt="image" src="https://github.com/user-attachments/assets/018557e2-4bb6-41be-b97a-0272f1b2a516" />
この下に「活動頻度」

## レビュアーへのメモ

<!-- レビュアーに特に注意して見てほしいポイントなどがあれば記載してください -->

## その他

<!-- 補足情報や注意点があれば記載してください -->
