### PR TITLE
fix-アピールポイント部分の画像を変更

### DIFF
--- a/src/data/mock-db.json
+++ b/src/data/mock-db.json
@@ -269,7 +269,7 @@
     "descriptionImage": "/ProfileExample.png",
     "appealPoint": {
       "text": "毎年、企業と連携したプロジェクトを実施しています。",
-      "image": ["/ProfileExample.png"]
+      "images": ["/ProfileExample.png","/ProfileExample.png"]
     },
     "researchProcess": [
       {


### PR DESCRIPTION
## やったこと
アピールポイントで画像が表示されないバグを解決
**原因**
mockDataとprops間で引数名の誤差が発生していた
アピールポイントの画像は複数持つ可能性があるので「image」から「images」とした

<!-- このPRで何を行ったかを簡潔に説明してください -->

## 変更内容

<!-- 変更した内容を詳しく記載してください -->

- [ ] 新機能の追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

## 関連 Issue
#87
<!-- 関連するIssueがあれば記載してください -->

- Closes #

## スクリーンショット
<img width="1163" height="399" alt="image" src="https://github.com/user-attachments/assets/bc476710-213d-4ddc-a0be-8144d0bacb60" />

## レビュアーへのメモ

<!-- レビュアーに特に注意して見てほしいポイントなどがあれば記載してください -->

## その他

<!-- 補足情報や注意点があれば記載してください -->
