### PR TITLE
担当授業について、授業が3つ以上の時もっと見るボタンを表示するようにした

### DIFF
--- a/src/app/professor/[name]/_component/LessonListView.tsx
+++ b/src/app/professor/[name]/_component/LessonListView.tsx
@@ -1,7 +1,6 @@
 "use client";
 import HeadLine from "@/components/HeadLine";
-import { BookOpen, ChevronDown } from "lucide-react";
-import { Clapperboard } from "lucide-react";
+import { BookOpen, ChevronDown, Clapperboard } from "lucide-react";
 import LessonCard from "./LessonCard";
 import YouTubeVideo from "@/components/YouTubeVideo";
 import { useState } from "react";

--- a/src/app/professor/[name]/_component/LessonListView.tsx
+++ b/src/app/professor/[name]/_component/LessonListView.tsx
@@ -1,8 +1,10 @@
+"use client";
 import HeadLine from "@/components/HeadLine";
-import { BookOpen } from "lucide-react";
-import { Clapperboard } from 'lucide-react';
+import { BookOpen, ChevronDown } from "lucide-react";
+import { Clapperboard } from "lucide-react";
 import LessonCard from "./LessonCard";
 import YouTubeVideo from "@/components/YouTubeVideo";
+import { useState } from "react";
 
 export type Lesson = {
   PK: string;
@@ -22,17 +24,36 @@ type LessonListViewProps = {
   courseYoutubeUrl?: string;
 };
 
-const LessonListView: React.FC<LessonListViewProps> = ({ lessons, courseYoutubeUrl }) => {
+const LessonListView: React.FC<LessonListViewProps> = ({
+  lessons,
+  courseYoutubeUrl,
+}) => {
+  const [showAll, setShowAll] = useState(false);
+  const visibleLessons = showAll ? lessons : lessons.slice(0, 3);
   return (
     <div className="mt-10">
       <HeadLine icon={<BookOpen className="w-10 h-10 " />} title="担当授業" />
       <div className="mt-5 space-y-4">
-        {lessons.map((lesson) => (
+        {visibleLessons.map((lesson) => (
           <LessonCard key={lesson.SK} lesson={lesson} />
         ))}
       </div>
+      {lessons.length > 4 && !showAll && (
+        <div className="mt-4">
+          <div
+            onClick={() => setShowAll(true)}
+            className="border border-gray-300 rounded-full p-3 lg:mx-50 mx-5 text-center flex items-center justify-center gap-2 cursor-pointer text-gray-400"
+          >
+            もっと見る
+            <ChevronDown className="w-5 h-5 text-gray-400" />
+          </div>
+        </div>
+      )}
       <div className="mt-8">
-        <HeadLine icon={<Clapperboard className="w-10 h-10 " />} title="担当授業紹介動画" />
+        <HeadLine
+          icon={<Clapperboard className="w-10 h-10 " />}
+          title="担当授業紹介動画"
+        />
       </div>
       <YouTubeVideo youtubeUrl={courseYoutubeUrl} title="担当授業紹介動画" />
     </div>

--- a/src/data/mock-db.json
+++ b/src/data/mock-db.json
@@ -178,7 +178,7 @@
     "researchTheme": "国際金融論",
     "officeLocation": "3-502"
   },
-   {
+  {
     "PK": "FACULTY#KEIZAI",
     "SK": "PROF#YAMADA",
     "professorName": "山田 四郎",
@@ -261,6 +261,42 @@
     "courseCode": "EC305",
     "syllabusLinkUrl": "https://portal.seikei.ac.jp/campusweb/slbssrch.do"
   },
+  {
+    "PK": "PROF#TANAKA",
+    "SK": "COURSE#EC102",
+    "courseName": "ミクロ経済学入門",
+    "description": "経済学の基本的な考え方を学びます。",
+    "learningPoints": "市場のメカニズムを理解する",
+    "style": "講義形式",
+    "relatedQualification": "公認会計士（一部）",
+    "targetGrade": ["1年生", "2年生"],
+    "courseCode": "EC101",
+    "syllabusLinkUrl": "https://portal.seikei.ac.jp/campusweb/slbssrch.do"
+  },
+  {
+    "PK": "PROF#TANAKA",
+    "SK": "COURSE#EC103",
+    "courseName": "ミクロ経済学入門",
+    "description": "経済学の基本的な考え方を学びます。",
+    "learningPoints": "市場のメカニズムを理解する",
+    "style": "講義形式",
+    "relatedQualification": "公認会計士（一部）",
+    "targetGrade": ["1年生", "2年生"],
+    "courseCode": "EC101",
+    "syllabusLinkUrl": "https://portal.seikei.ac.jp/campusweb/slbssrch.do"
+  },
+  {
+    "PK": "PROF#TANAKA",
+    "SK": "COURSE#EC104",
+    "courseName": "ミクロ経済学入門",
+    "description": "経済学の基本的な考え方を学びます。",
+    "learningPoints": "市場のメカニズムを理解する",
+    "style": "講義形式",
+    "relatedQualification": "公認会計士（一部）",
+    "targetGrade": ["1年生", "2年生"],
+    "courseCode": "EC101",
+    "syllabusLinkUrl": "https://portal.seikei.ac.jp/campusweb/slbssrch.do"
+  },
 
   {
     "PK": "PROF#TANAKA",
@@ -270,7 +306,7 @@
     "descriptionImage": "/ProfileExample.png",
     "appealPoint": {
       "text": "毎年、企業と連携したプロジェクトを実施しています。",
-      "images": ["/ProfileExample.png","/ProfileExample.png"]
+      "images": ["/ProfileExample.png", "/ProfileExample.png"]
     },
     "researchProcess": [
       {


### PR DESCRIPTION
## やったこと
- 担当授業のところで、授業が3つ以上の時もっと見るボタンを表示するようにした
- もっと見るボタンを押すと全ての授業を見ることができる

## 変更内容

<!-- 変更した内容を詳しく記載してください -->

- [x] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

## 関連 Issue

- Closes #70 

## スクリーンショット

## PC

https://github.com/user-attachments/assets/df6c831c-dd95-48be-af5a-b2ca39c8fba9


## MP


https://github.com/user-attachments/assets/4cb0d4b0-de27-4095-9e54-8688cf54cbec






## レビュアーへのメモ

<!-- レビュアーに特に注意して見てほしいポイントなどがあれば記載してください -->

## その他

<!-- 補足情報や注意点があれば記載してください -->
