### PR TITLE
活動曜日群の余白設定を統一

### DIFF
--- a/src/app/professor/[name]/_component/seminar/SeminarInfoView.tsx
+++ b/src/app/professor/[name]/_component/seminar/SeminarInfoView.tsx
@@ -101,21 +101,23 @@ const SeminarInfoView = ({
           <SeminarSchedule seminarSchedule={seminarSchedule} />
         </div>
       </div>
-      <div className="flex flex-col lg:flex-row gap-5 lg:gap-10 mt-5 ml-5">
-        <div className="max-w-[300px] lg:max-w-[500px] lg:mx-auto lg:mb-0">
-          <h2 className="text-xl font-bold mb-2">活動曜日・頻度</h2>
+      <div className="grid lg:grid-cols-[auto_1fr_auto] px-4 lg:px-[200px] gap-5">
+        <div className="lg:justify-self-start">
+          <h2 className="text-lg lg:text-xl font-bold mb-2">活動曜日・頻度</h2>
           {activityDay && activityDay.length > 0 ? (
             activityDay.map((day, index) => {
-              // 曜日とそれ以外の情報（今は時限）を分ける
               const parts = day.split(" ");
               const dayOfWeek = parts[0] || "";
               const period = parts[1] || "";
 
               return (
-                <div key={index} className="flex items-center mb-1 text-lg">
+                <div
+                  key={index}
+                  className="flex items-center mb-1 ml-2 text-lg"
+                >
                   <span className="mr-2">・</span>
-                  <span className="font-bold">{dayOfWeek}</span>
-                  <span className="ml-4">{period}</span>
+                  <span className="lg:font-bold ml-4">{dayOfWeek}</span>
+                  <span className="ml-2">{period}</span>
                 </div>
               );
             })
@@ -123,23 +125,30 @@ const SeminarInfoView = ({
             <p>活動日の情報がありません</p>
           )}
         </div>
-        <div className="max-w-[300px] lg:max-w-[500px] lg:mx-auto lg:mb-0">
-          <h2 className="text-xl font-bold mb-2">特徴・キーワード</h2>
+        <div className="lg:justify-self-center">
+          <h2 className="text-lg lg:text-xl font-bold mb-2">
+            特徴・キーワード
+          </h2>
           {keywords.map((keyword) => (
             <Badge
               key={keyword}
-              className="flex flex-col bg-[#fff7f9] text-[#FF8888] border border-[#FF8888] rounded-full px-4 mb-2 text-sm"
+              className="flex flex-col bg-[#fff7f9] text-[#FF8888] border border-[#FF8888] rounded-full px-4 ml-2 mb-2 text-sm"
             >
               # {keyword}
             </Badge>
           ))}
         </div>
-        <div className="max-w-[300px] lg:max-w-[500px] lg:mx-auto lg:mb-0">
-          <h2 className="text-xl font-bold mb-2">卒業生の研究テーマ</h2>
+        <div className="lg:justify-self-end">
+          <h2 className="text-lg lg:text-xl font-bold mb-2">
+            卒業生の研究テーマ
+          </h2>
           {graduateThemes && graduateThemes.length > 0 ? (
             graduateThemes.map((theme, index) => {
               return (
-                <div key={index} className="flex items-center mb-1 text-lg">
+                <div
+                  key={index}
+                  className="flex items-center mb-1 ml-2 text-lg"
+                >
                   <span className="mr-2">・</span>
                   <span className="ml-4">{theme}</span>
                 </div>


### PR DESCRIPTION
## やったこと
- **活動曜日群のマージン**が他の要素と違うあたり方をしていたので**同じに見えるようCSSを変更**
- スマホ画面で他の要素と合うように修正
<!-- このPRで何を行ったかを簡潔に説明してください -->

## 変更内容
**「活動曜日・頻度」「特徴・キーワード」「卒業生の研究テーマ」の余白**が、他の要素と違うあたり方（位置が固定されていない）をしていたので、**どんな画面の大きさでも位置が固定されるよう修正**した。
<!-- 変更した内容を詳しく記載してください -->

- [ ] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] その他: 余白設定の見直し

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

- Closes #97 

## スクリーンショット
### PC画面
<img width="1916" height="945" alt="image" src="https://github.com/user-attachments/assets/93a6e664-766d-45cd-bc7c-789dd7011f7f" />

gridでCSSを当てることにより**3要素をうまく配置し直した**。
（他の要素と同じflexのCSSにしてもうまくいかないのは、要素が3つあって大きさが一致してなかったことが原因でした。）

### スマホ画面
<img width="438" height="482" alt="image" src="https://github.com/user-attachments/assets/2a1c8585-042b-4e2c-bc71-6a638c3b9ede" />

他の要素のCSSより**悪目立ちしていた部分**（太字や文字の大きさ、余白幅など）を**修正**。

## レビュアーへのメモ

<!-- レビュアーに特に注意して見てほしいポイントなどがあれば記載してください -->

## その他

<!-- 補足情報や注意点があれば記載してください -->
